### PR TITLE
Allow custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ var opts = {
   },
   strictSSL: false,
   followAllRedirects: true,
-  followRedirect: true
+  followRedirect: true,
+  headers: {
+    'x-custom': 'headers'
+  }
 };
 waitOn(opts, function (err) {
   if (err) { return handleError(err); }
@@ -187,7 +190,8 @@ waitOn(opts, cb) - function which triggers resource checks
    - opts.httpSignature: { keyId, key }
    - opts.strictSSL: false,
    - opts.followAllRedirects: true,
-   - opts.followRedirect: true
+   - opts.followRedirect: true,
+   - opts.headers: { 'x-custom': 'headers' },
 
  - cb(err) - if err is provided then, resource checks did not succeed
 

--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -15,5 +15,8 @@ module.exports = {
   },
   strictSSL: false,
   followAllRedirects: false,
-  followRedirect: false
+  followRedirect: false,
+  headers: {
+    'x-custom': 'headers'
+  }
 };

--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -38,7 +38,8 @@ var WAIT_ON_SCHEMA = Joi.object().keys({
   }),
   strictSSL: Joi.boolean(),
   followAllRedirects: Joi.boolean(),
-  followRedirect: Joi.boolean()
+  followRedirect: Joi.boolean(),
+  headers: Joi.object()
 });
 
 /**
@@ -191,7 +192,7 @@ function parseHttpOptions(options) {
   if (options === undefined) return {}
   var valid = [
     // https://github.com/request/request/tree/c289759d10ebd76ff4138e81b39c81badde6e274#requestoptions-callback
-    'auth', 'httpSignature', 'followRedirect', 'followAllRedirects', 'strictSSL',
+    'auth', 'httpSignature', 'followRedirect', 'followAllRedirects', 'strictSSL', 'headers',
     // https://github.com/request/request/tree/c289759d10ebd76ff4138e81b39c81badde6e274#tlsssl-protocol
     'cert', 'key', 'passphrase', 'ca'
   ];


### PR DESCRIPTION
I ran into an issue, while using webpack-dev-server, where a page returned a `200` status code in my browser, but returned a 404 to this library. After much digging, it turned out this was due to the fact that [the `accept` header was missing](https://github.com/bripkens/connect-history-api-fallback/blob/master/lib/index.js#L19).

To solve this issue in a generic way, I've added `headers` to the list of accepted request options, added it to the Joi schema, and added it to the readme and example config. I've tested this patch in my own codebase and it works as expected.

I was going to add a test for this, but realised that the other request options aren't currently tested either. Happy to add a test if you feel it's necessary, but I decided to follow existing patterns.