### PR TITLE
add allowAnyResponse to config files. resolves #45

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -18,5 +18,8 @@ module.exports = {
   followRedirect: false,
   headers: {
     'x-custom': 'headers'
-  }
+  },
+
+  //set this to 'true' to accept all GET and HEAD response codes as a success (not only 2XX)
+  allowAnyResponse: false
 };

--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -41,7 +41,8 @@ var WAIT_ON_SCHEMA = Joi.object().keys({
   strictSSL: Joi.boolean(),
   followAllRedirects: Joi.boolean(),
   followRedirect: Joi.boolean(),
-  headers: Joi.object()
+  headers: Joi.object(),
+  allowAnyResponse: Joi.bool()
 });
 
 /**
@@ -274,11 +275,12 @@ function createHttp$(url, options) {
   )
   .map(function (response) {
     // Why is response in array here?
-    var statusCode = response[0].statusCode;
+    var statusCode = response[0].statusCode;    
     return {
       // request will handle redirects before returning
-      // anything but 2XX is a failure
-      val: (statusCode >= 200 && statusCode <= 299) ?
+      // anything but 2XX is a failure if options.allowAnyResponse set to true
+      // allowAnyResponse: still compare to 600 as sometimes 999 codes are returned even if the resource is not reachable  
+      val: (options.allowAnyResponse && statusCode < 600 || statusCode >= 200 && statusCode <= 299) ?
         statusCode :
         -1 * statusCode,
       data: response[0]
@@ -297,7 +299,7 @@ function createHttpGet$(url, options) {
     return {
       // request will handle redirects before returning
       // anything but 2XX is a failure
-      val: (statusCode >= 200 && statusCode <= 299) ?
+      val: (options.allowAnyResponse && statusCode < 600 || statusCode >= 200 && statusCode <= 299) ?
         statusCode :
         -1 * statusCode,
       data: response[0]

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -233,6 +233,33 @@ describe('api', function () {
     });
   });
 
+  it('should succeed when an http resource returns 404 and allowAnyResponse is set', function (done) {
+    var opts = {
+      resources: [
+        'http://localhost:3002'
+      ],
+      timeout: 1000,
+      interval: 100,
+      window: 100,
+      allowAnyResponse: true
+    };
+
+    setTimeout(function () {
+      httpServer = http.createServer()
+        .on('request', function (req, res) {
+          res.statusCode = 404;
+          res.end('data');
+        });
+      httpServer.listen(3002, 'localhost');
+    }, 300);
+
+    waitOn(opts, function (err) {
+      expect(err).toNotExist();
+      done();
+    });
+  });
+
+
   // Error situations
 
   it('should timeout when all resources are not available and timout option is specified', function (done) {
@@ -265,7 +292,7 @@ describe('api', function () {
     });
   });
 
-  it('should timeout when an http resource returns 404', function (done) {
+  it('should timeout when an http resource returns 404 and allowAnyResponse is not set', function (done) {
     var opts = {
       resources: [
         'http://localhost:3002'
@@ -298,6 +325,23 @@ describe('api', function () {
       timeout: 1000,
       interval: 100,
       window: 100
+    };
+
+    waitOn(opts, function (err) {
+      expect(err).toExist();
+      done();
+    });
+  });
+
+  it('should timeout when an http resource is not available even if allowAnyResponse is set', function (done) {
+    var opts = {
+      resources: [
+        'http://localhost:3010'
+      ],
+      timeout: 1000,
+      interval: 100,
+      window: 100,
+      allowAnyResponse: true
     };
 
     waitOn(opts, function (err) {


### PR DESCRIPTION
`allowAnyResponse` flag was added to --config file. If set to `true` it makes `wait-on` accept 3XX, 4XX and 5XX responses to HEAD and GET requests as a success. This feature was requested in #45.