### PR TITLE
[Api]: QOL imporvement. Allow string as opts.

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -80,6 +80,8 @@ const WAIT_ON_SCHEMA = Joi.object({
    if not specified, wait-on will return a promise that will be rejected if resource checks did not succeed or resolved otherwise
  */
 function waitOn(opts, cb) {
+  if (typeof opts === "string") opts = {resources: [opts]}
+  
   if (cb !== undefined) {
     return waitOnImpl(opts, cb);
   } else {


### PR DESCRIPTION
Allows for cli like usage

```ts
await waitOn("myFile")
```

Equivalent to

```ts
await waitOn({
  resources: [
    "myFile"
  ]
})
```