### PR TITLE
`ignoreProxy` for axios request

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -48,6 +48,7 @@ const WAIT_ON_SCHEMA = Joi.object({
     password: Joi.string(),
   }),
   strictSSL: Joi.boolean().default(false),
+  ignoreProxy: Joi.boolean().default(false),
   followRedirect: Joi.boolean().default(true), // HTTP 3XX responses
   headers: Joi.object(),
 });
@@ -267,6 +268,7 @@ function createHTTP$({ validatedOpts, output }, resource) {
     reverse,
     simultaneous,
     strictSSL: rejectUnauthorized,
+    ignoreProxy,
   } = validatedOpts;
   const method = HTTP_GET_RE.test(resource) ? 'get' : 'head';
   const url = resource.replace('-get:', ':');
@@ -284,6 +286,7 @@ function createHTTP$({ validatedOpts, output }, resource) {
     ...(followRedirect ? {} : { maxRedirects: 0 }), // defaults to 5 (enabled)
     ...(timeout && { timeout }),
     ...urlSocketOptions,
+    ...(ignoreProxy ? { proxy: false }: {}), // axios no proxy
     method,
     // by default it provides full response object
     // validStatus is 2xx unless followRedirect is true (default)


### PR DESCRIPTION
set `proxy: false` for axios config to handle proxy enabled systems, handle `proxy` system when `http_proxy` variables are set.
https://github.com/axios/axios/issues/1514#issuecomment-392650702