### PR TITLE
fix: Cannot find module 'lodash/fp'

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -8,7 +8,7 @@ const net = require('net');
 const util = require('util');
 const axiosPkg = require('axios').default;
 const axiosHttpAdapter = require('axios/lib/adapters/http');
-const { isBoolean, isEmpty, negate, noop, once, partial, pick, zip } = require('lodash/fp');
+const { isBoolean, isEmpty, negate, noop, once, partial, pick, zip } = require('lodash');
 const { NEVER, combineLatest, from, merge, throwError, timer } = require('rxjs');
 const { distinctUntilChanged, map, mergeMap, scan, startWith, take, takeWhile } = require('rxjs/operators');
 


### PR DESCRIPTION
Full Stacktrace:
```
Error: Cannot find module 'lodash/fp'
Require stack:
- /home/runner/work/try-playwright/try-playwright/node_modules/wait-on/lib/wait-on.js
```

See here: https://github.com/mxschmitt/try-playwright/pull/116/checks?check_run_id=849509692#step:9:10

Actually not sure why lodash/fp will be used here, seems like its outdated.