### PR TITLE
Expose the remaining resources in timeout error messages (#72)

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -22,7 +22,7 @@ const PREFIX_RE = /^((https?-get|https?|tcp|socket|file):)(.+)$/;
 const HOST_PORT_RE = /^(([^:]*):)?(\d+)$/;
 const HTTP_GET_RE = /^https?-get:/;
 const HTTP_UNIX_RE = /^http:\/\/unix:([^:]+):([^:]+)$/;
-const TIMEOUT_ERR_MSG = 'Timeout';
+const TIMEOUT_ERR_MSG = 'Timed out waiting for';
 
 const WAIT_ON_SCHEMA = Joi.object({
   resources: Joi.array().items(Joi.string().required()).required(),
@@ -125,13 +125,15 @@ function waitOnImpl(opts, cbFunc) {
   let lastResourcesState = resources; // the last state we had recorded
 
   const timeoutError$ =
-    timeout !== Infinity ? timer(timeout).pipe(mergeMap(() => throwError(Error('Timeout')))) : NEVER;
+    timeout !== Infinity ? timer(timeout).pipe(mergeMap(() => {
+      const resourcesWaitingFor = determineRemainingResources(resources, lastResourcesState).join(', ')
+      return throwError(Error(`${TIMEOUT_ERR_MSG}: ${resourcesWaitingFor}`))
+    })) : NEVER;
 
   function cleanup(err) {
     if (err) {
-      if (err.message === TIMEOUT_ERR_MSG) {
-        const resourcesWaitingFor = determineRemainingResources(resources, lastResourcesState).join(', ');
-        log('wait-on(%s) timed out waiting for: %s; exiting with error', process.pid, resourcesWaitingFor);
+      if (err.message.startsWith(TIMEOUT_ERR_MSG)) {
+        log('wait-on(%s) %s; exiting with error', process.pid, err.message);
       } else {
         log('wait-on(%s) exiting with error', process.pid, err);
       }


### PR DESCRIPTION
Implements #72 

I tried to log errors straight away, however, that introduced stack traces for timeout errors which were previously omitted:
```
waiting for 6 resources: http://localhost:9333/bar, tcp:localhost:9333, http://localhost:9444/bar, tcp:localhost:9444, http://localhost:9555/bar, tcp:localhost:9666
waiting for 5 resources: http://localhost:9333/bar, http://localhost:9444/bar, tcp:localhost:9444, http://localhost:9555/bar, tcp:localhost:9666
waiting for 4 resources: http://localhost:9333/bar, http://localhost:9444/bar, http://localhost:9555/bar, tcp:localhost:9666
waiting for 3 resources: http://localhost:9333/bar, http://localhost:9555/bar, tcp:localhost:9666
waiting for 2 resources: http://localhost:9555/bar, tcp:localhost:9666
waiting for 1 resources: tcp:localhost:9666
wait-on(2656) exiting with error Error: timed out waiting for: tcp:localhost:9666
    at MergeMapSubscriber.project (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/wait-on/lib/wait-on.js:129:1)
    at MergeMapSubscriber.module.exports.MergeMapSubscriber._tryNext (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/operators/mergeMap.js:67:1)
    at MergeMapSubscriber.module.exports.MergeMapSubscriber._next (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/operators/mergeMap.js:57:1)
    at MergeMapSubscriber.module.exports.Subscriber.next (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/Subscriber.js:66:1)
    at AsyncAction.dispatch [as work] (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/observable/timer.js:31:1)
    at AsyncAction.module.exports.AsyncAction._execute (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/scheduler/AsyncAction.js:71:1)
    at AsyncAction.module.exports.AsyncAction.execute (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/scheduler/AsyncAction.js:59:1)
    at AsyncScheduler.module.exports.AsyncScheduler.flush (/home/runner/work/fuzzy-winner/fuzzy-winner/node_modules/rxjs/internal/scheduler/AsyncScheduler.js:52:1)
    at listOnTimeout (internal/timers.js:531:17)
    at processTimers (internal/timers.js:475:7)
```

With the quick/nasty check in place now, we omit stack traces for errors that look like our timeout errors.
```
waiting for 6 resources: http://localhost:9333/bar, tcp:localhost:9333, http://localhost:9444/bar, tcp:localhost:9444, http://localhost:9555/bar, tcp:localhost:9666
waiting for 5 resources: http://localhost:9333/bar, http://localhost:9444/bar, tcp:localhost:9444, http://localhost:9555/bar, tcp:localhost:9666
waiting for 4 resources: http://localhost:9444/bar, tcp:localhost:9444, http://localhost:9555/bar, tcp:localhost:9666
waiting for 3 resources: http://localhost:9444/bar, http://localhost:9555/bar, tcp:localhost:9666
waiting for 2 resources: http://localhost:9555/bar, tcp:localhost:9666
waiting for 1 resources: tcp:localhost:9666
wait-on(2557) exiting with error; timed out waiting for: tcp:localhost:9666
```