### PR TITLE
Allow for resources to be passed via config

### DIFF
--- a/bin/wait-on
+++ b/bin/wait-on
@@ -40,8 +40,10 @@ if (argv.help || !argv._.length) {
     opts = require(path.resolve(configFile));
   }
 
-  // add in the resources listed on the command line
-  opts.resources = argv._;
+  // add in the resources listed on the command line (if not present in config)
+  if (!opts.resources) { 
+    opts.resources = argv._;
+  }
 
   // now check for specific options and set those
   opts = [

--- a/bin/wait-on
+++ b/bin/wait-on
@@ -24,7 +24,7 @@ var minimistOpts = {
 
 var argv = minimist(process.argv.slice(2), minimistOpts);
 
-if (argv.help || !argv._.length) {
+if (argv.help) {
   // help
   fs.createReadStream(path.join(__dirname, '/usage.txt'))
     .pipe(process.stdout)


### PR DESCRIPTION
This allows for resources to be passed via the config. Currently `argv._` overwrites that property. With this change it is easier to wait for multiple resources without having to add them in the cmd line.