### PR TITLE
Allow specifying time-outs in seconds/minutes/hours

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -68,10 +68,17 @@ Standard Options:
 
   Maximum time in ms to wait before exiting with failure (1) code,
   default Infinity
+  Use postfix 'ms', 's', 'm' or 'h' to change the unit.
 
   --tcpTimeout
 
   Maximum time in ms for tcp connect, default 300ms
+  Use postfix 'ms', 's', 'm' or 'h' to change the unit.
+
+  --httpTimeout
+
+  Maximum time to wait for the HTTP request, default Infinity
+  Use postfix 'ms', 's', 'm' or 'h' to change the unit.
 
  -v, --verbose
 

--- a/bin/wait-on
+++ b/bin/wait-on
@@ -5,8 +5,9 @@ const minimist = require('minimist');
 const path = require('path');
 const waitOn = require('../');
 
+const interval = ['timeout', 'httpTimeout', 'tcpTimeout'];
 const minimistOpts = {
-  string: ['c', 'd', 'i', 's', 't', 'w', 'httpTimeout', 'tcpTimeout'],
+  string: ['c', 'd', 'i', 's', 't', 'w'].concat(interval),
   boolean: ['h', 'l', 'r', 'v'],
   alias: {
     c: 'config',
@@ -57,7 +58,11 @@ if (argv.help || !argv._.length) {
     'window',
   ].reduce(function (accum, x) {
     if (argv[x]) {
-      accum[x] = argv[x];
+      let value = argv[x];
+      if (interval.includes(x)) {
+        value = parseInterval(value);
+      }
+      accum[x] = value;
     }
     return accum;
   }, opts);
@@ -80,4 +85,19 @@ function errorExit(err) {
     console.error(String(err));
   }
   process.exit(1);
+}
+
+function parseInterval(arg) {
+  const res = /^([\d.]+)(|ms|s|m|h)$/i.exec(arg);
+  if (!res) {
+    return arg;
+  }
+  const value = parseFloat(res[1]);
+  switch (res[2]) {
+    case '':
+    case 'ms': return Math.floor(value);
+    case 's': return Math.floor(value * 1000);
+    case 'm': return Math.floor(value * 1000 * 60);
+    case 'h': return Math.floor(value * 1000 * 60 * 60);
+  }
 }

--- a/test/cli.mocha.js
+++ b/test/cli.mocha.js
@@ -22,7 +22,7 @@ function execCLI(args, options) {
   return childProcess.spawn(process.execPath, fullArgs, options);
 }
 
-const FAST_OPTS = '-t 1000 -i 100 -w 100'.split(' ');
+const FAST_OPTS = '-t 1s -i 100 -w 100'.split(' ');
 
 describe('cli', function () {
   this.timeout(3000);


### PR DESCRIPTION
It feels a bit weird to specify large intervals in milliseconds. I assume most of them would be >1 second. This change allows you to specify the timeouts in seconds, minutes and hours as well.
The default is still 'ms' to maintain backwards compatibility.