### PR TITLE
Correct auth section of exampleConfig.js

### DIFF
--- a/exampleConfig.js
+++ b/exampleConfig.js
@@ -12,8 +12,8 @@ module.exports = {
   ],
   passphrase: 'yourpassphrase',
   auth: {
-    user: 'yourusername',
-    pass: 'yourpassword'
+    username: 'yourusername',
+    password: 'yourpassword'
   },
   strictSSL: false,
   followRedirect: false,


### PR DESCRIPTION
Auth section should be `username`/`password` rather than `user`/`pass`.

The application complains if you use the short-form.