### PR TITLE
Add new flag httpContains to check for string in body of response

### DIFF
--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -46,6 +46,11 @@ Standard Options:
   Maximum time in ms to wait for an HTTP HEAD/GET request, default 0
   which results in using the OS default
 
+ --httpContains
+
+  string to check in http response, will wait until response body contains this value. 
+  To be used with http(s)-get
+
  -i, --interval
 
   Interval to poll resources in ms, default 250ms

--- a/bin/wait-on
+++ b/bin/wait-on
@@ -6,7 +6,7 @@ const path = require('path');
 const waitOn = require('../');
 
 const minimistOpts = {
-  string: ['c', 'd', 'i', 's', 't', 'w', 'httpTimeout', 'tcpTimeout'],
+  string: ['c', 'd', 'i', 's', 't', 'w', 'httpTimeout','httpContains', 'tcpTimeout'],
   boolean: ['h', 'l', 'r', 'v'],
   alias: {
     c: 'config',
@@ -45,6 +45,7 @@ if (argv.help || !hasResources) {
   const opts = [
     'delay',
     'httpTimeout',
+    'httpContains',
     'interval',
     'log',
     'reverse',

--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -28,6 +28,7 @@ const WAIT_ON_SCHEMA = Joi.object({
   resources: Joi.array().items(Joi.string().required()).required(),
   delay: Joi.number().integer().min(0).default(0),
   httpTimeout: Joi.number().integer().min(0),
+  httpContains: Joi.string(),
   interval: Joi.number().integer().min(0).default(250),
   log: Joi.boolean().default(false),
   reverse: Joi.boolean().default(false),
@@ -74,6 +75,7 @@ const WAIT_ON_SCHEMA = Joi.object({
    @param opts.resources array of string resources to wait for. prefix determines the type of resource with the default type of `file:`
    @param opts.delay integer - optional initial delay in ms, default 0
    @param opts.httpTimeout integer - optional http HEAD/GET timeout to wait for request, default 0
+   @param opts.httpContains string - optional the string http response needs to contain
    @param opts.interval integer - optional poll resource interval in ms, default 250ms
    @param opts.log boolean - optional flag to turn on logging to stdout
    @param opts.reverse boolean - optional flag which reverses the mode, succeeds when resources are not available
@@ -270,6 +272,7 @@ function createHTTP$({ validatedOpts, output }, resource) {
     delay,
     followRedirect,
     httpTimeout: timeout,
+    httpContains,
     interval,
     proxy,
     reverse,
@@ -301,7 +304,7 @@ function createHTTP$({ validatedOpts, output }, resource) {
   return timer(delay, interval).pipe(
     mergeMap(() => {
       output(`making HTTP(S) ${method} request to ${socketPathDesc} url:${urlSocketOptions.url} ...`);
-      return from(checkFn(output, httpOptions));
+      return from(checkFn(output, httpOptions, httpContains));
     }, simultaneous),
     startWith(false),
     distinctUntilChanged(),
@@ -309,7 +312,7 @@ function createHTTP$({ validatedOpts, output }, resource) {
   );
 }
 
-async function httpCallSucceeds(output, httpOptions) {
+async function httpCallSucceeds(output, httpOptions, httpContains) {
   try {
     const result = await axios(httpOptions);
     output(
@@ -317,6 +320,17 @@ async function httpCallSucceeds(output, httpOptions) {
         pick(['status', 'statusText', 'headers', 'data'], result)
       )}`
     );
+    if(httpContains){
+      if(!result.data){
+        output(`  HTTP(S) response is empty for ${httpOptions.url}`);
+        return false;
+      }
+      if(!result.data.includes(httpContains)){
+        output(`  HTTP(S) response does not contain string ${httpContains} for ${httpOptions.url}`);
+        return false;
+      }
+    }
+
     return true;
   } catch (err) {
     output(`  HTTP(S) error for ${httpOptions.url} ${err.toString()}`);

--- a/test/api.mocha.js
+++ b/test/api.mocha.js
@@ -144,6 +144,26 @@ describe('api', function () {
     });
   });
 
+  it('should succeed when http GET contains httpContains value', function (done) {
+    const opts = {
+      resources: ['http-get://localhost:3000'],
+      httpContains: "abc123"
+    };
+
+    setTimeout(function () {
+      httpServer = http.createServer().on('request', function (req, res) {
+        res.write("abc123");
+        res.end('data');
+      });
+      httpServer.listen(3000, 'localhost');
+    }, 300);
+
+    waitOn(opts, function (err) {
+      expect(err).toNotExist();
+      done();
+    });
+  });
+
   it('should succeed when http GET resource become available later via redirect', function (done) {
     const opts = {
       // followRedirect: true, // default is true
@@ -449,6 +469,31 @@ describe('api', function () {
       const pathname = req.url;
       if (pathname === '/') {
         res.writeHead(302, { Location: 'http://localhost:3000/foo' });
+      }
+      res.end('data');
+    });
+    httpServer.listen(3000, 'localhost');
+
+    waitOn(opts, function (err) {
+      expect(err).toExist();
+      done();
+    });
+  });
+
+  it('should timeout when http response does not contain requested string', function (done) {
+    const opts = {
+      timeout: 1000,
+      interval: 100,
+      window: 100,
+      followRedirect: false,
+      httpContains: "12345",
+      resources: ['http-get://localhost:3000']
+    };
+
+    httpServer = http.createServer().on('request', function (req, res) {
+      const pathname = req.url;
+      if (pathname === '/') {
+        res.write("abc123")
       }
       res.end('data');
     });

--- a/test/cli.mocha.js
+++ b/test/cli.mocha.js
@@ -568,5 +568,42 @@ describe('cli', function () {
         done();
       });
     });
+
+    it('should succeed when http response contains httpContains value', function (done) {
+      setTimeout(function () {
+        httpServer = http.createServer().on('request', function (req, res) {
+          res.write("abc123");
+          res.end('data');
+        });
+        httpServer.listen(3030, 'localhost');
+      }, 300);
+
+      execCLI(
+        ['--httpContains abc123', 'http-get://localhost:3030/'].concat(FAST_OPTS),
+        {}
+      ).on('exit', function (code) {
+        expect(code).toBe(0);
+        done();
+      });
+    });
+
+    it('should timeout when http response does not contain httpContains value', function (done) {
+      setTimeout(function () {
+        httpServer = http.createServer().on('request', function (req, res) {
+          res.write("abc123");
+          res.end('data');
+        });
+        httpServer.listen(3030, 'localhost');
+      }, 300);
+
+      execCLI(
+        ['--httpContains 1234', 'http-get://localhost:3030/'].concat(FAST_OPTS),
+        {}
+      ).on('exit', function (code) {
+        expect(code).toBe(0);
+        done();
+      });
+    });    
+
   });
 });


### PR DESCRIPTION
We have some code that needs to wait until the target URL is updated with the latest version of code. Adding httpContains allows us to wait until we see the new hash in the target http response and accomplish that, thought this may be useful for others.