### PR TITLE
Add support for custom HTTP(S) agents

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -50,7 +50,9 @@ const WAIT_ON_SCHEMA = Joi.object({
   }),
   strictSSL: Joi.boolean().default(false),
   followRedirect: Joi.boolean().default(true), // HTTP 3XX responses
-  headers: Joi.object()
+  headers: Joi.object(),
+  httpAgent: Joi.object(),
+  httpsAgent: Joi.object(),
 });
 
 /**
@@ -274,7 +276,9 @@ function createHTTP$({ validatedOpts, output }, resource) {
     proxy,
     reverse,
     simultaneous,
-    strictSSL: rejectUnauthorized
+    strictSSL: rejectUnauthorized,
+    httpAgent,
+    httpsAgent
   } = validatedOpts;
   const method = HTTP_GET_RE.test(resource) ? 'get' : 'head';
   const url = resource.replace('-get:', ':');
@@ -283,12 +287,16 @@ function createHTTP$({ validatedOpts, output }, resource) {
     ? { socketPath: matchHttpUnixSocket[1], url: matchHttpUnixSocket[2] }
     : { url };
   const socketPathDesc = urlSocketOptions.socketPath ? `socketPath:${urlSocketOptions.socketPath}` : '';
-  const httpOptions = {
-    ...pick(['auth', 'headers', 'validateStatus'], validatedOpts),
-    httpsAgent: new https.Agent({
+  if (!httpsAgent) {
+    httpsAgent = new https.Agent({
       rejectUnauthorized,
       ...pick(['ca', 'cert', 'key', 'passphrase'], validatedOpts)
-    }),
+    });
+  };
+  const httpOptions = {
+    ...pick(['auth', 'headers', 'validateStatus'], validatedOpts),
+    httpAgent: httpAgent,
+    httpsAgent: httpsAgent,
     ...(followRedirect ? {} : { maxRedirects: 0 }), // defaults to 5 (enabled)
     proxy, // can be undefined, false, or object
     ...(timeout && { timeout }),


### PR DESCRIPTION
Hi,

I had the need to use `wait-on` for HTTP requests via a SOCKS proxy, so I added the functionality to hand over custom Agents to Axios. The agents are optional in Axios configs, so the handover of `undefined` should be fine.

If you would like something changed, please tell me. I'm not so familiar with some of the JS syntax you use here, so please bare with me if I missed something.

Since a custom HTTPS agent will make the use of properties `['ca', 'cert', 'key', 'passphrase']` obsolete, maybe we should put a hint to the docs...?