### PR TITLE
Migrate from Travis to GitHub Actions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@ module.exports = {
     mocha: true,
   },
   plugins: ['chai-friendly'],
-  extends: ['standard', 'prettier', 'prettier/standard'],
+  extends: ['standard', 'prettier'],
   root: true,
   rules: {
     'no-use-before-define': 'off',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  lint:
+    name: Lint
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run lint
+
+  test:
+    name: Tests (Node.js ${{ matrix.node }})
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node:
+          - '10'
+          - '11'
+          - '12'
+          - '14'
+          - '16'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: node_js
-node_js:
-  - '10'
-  - '11'
-  - '12'
-  - '14'
-  - node

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For http(s) resources wait-on will check that the requests are returning 2XX (su
 
 wait-on can also be used in reverse mode which waits for resources to NOT be available. This is useful in waiting for services to shutdown before continuing. (Thanks @skarbovskiy for adding this feature)
 
-[![Build Status](https://travis-ci.com/jeffbski/wait-on.svg?branch=master)](https://travis-ci.com/jeffbski/wait-on)
+[![CI](https://github.com/jeffbski/wait-on/actions/workflows/ci.yml/badge.svg)](https://github.com/jeffbski/wait-on/actions/workflows/ci.yml)
 
 ## Installation
 


### PR DESCRIPTION
Here you can see it running if you're interested (before I removed gh-actions branch from the list of branches to run CI on automatically): https://github.com/wojtekmaj/wait-on/actions/runs/1711985636