### PR TITLE
fix: update axios to 1.6.1 to fix CVE-2023-45857

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -7,14 +7,13 @@ const https = require('https');
 const net = require('net');
 const util = require('util');
 const axiosPkg = require('axios').default;
-const axiosHttpAdapter = require('axios/lib/adapters/http');
 const { isBoolean, isEmpty, negate, noop, once, partial, pick, zip } = require('lodash/fp');
 const { NEVER, combineLatest, from, merge, throwError, timer } = require('rxjs');
 const { distinctUntilChanged, map, mergeMap, scan, startWith, take, takeWhile } = require('rxjs/operators');
 
 // force http adapter for axios, otherwise if using jest/jsdom xhr might
 // be used and it logs all errors polluting the logs
-const axios = axiosPkg.create({ adapter: axiosHttpAdapter });
+const axios = axiosPkg.create({ adapter: 'http' });
 const isNotABoolean = negate(isBoolean);
 const isNotEmpty = negate(isEmpty);
 const fstat = promisify(fs.stat);

--- a/package-lock.json
+++ b/package-lock.json
@@ -158,7 +158,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -352,12 +353,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
+      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "balanced-match": {
@@ -825,13 +827,15 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.0.0.tgz",
       "integrity": "sha512-IcJsTkJae2S35pRsRAwoCE+925rJJStOdkKnLVgtE+tEpqU0EVVM7OqrwxqgptKdX29NUwC82I5pXsGFIgSevw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
       "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.9",
@@ -879,7 +883,8 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz",
       "integrity": "sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-es": {
       "version": "3.0.1",
@@ -1020,7 +1025,8 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
       "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -2167,6 +2173,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -353,9 +353,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-      "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temp": "^0.9.4"
   },
   "dependencies": {
-    "axios": "^0.27.2",
+    "axios": "^1.6.0",
     "joi": "^17.11.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "temp": "^0.9.4"
   },
   "dependencies": {
-    "axios": "^1.6.0",
+    "axios": "^1.6.1",
     "joi": "^17.11.0",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",


### PR DESCRIPTION
Axios was recently updated to fix CVE-2023-45857. This PR is to update to axios 1.6.0.