### PR TITLE
Use JSDoc brackets to indicate optional cb param

### DIFF
--- a/lib/wait-on.js
+++ b/lib/wait-on.js
@@ -81,7 +81,7 @@ const WAIT_ON_SCHEMA = Joi.object({
    @param opts.timeout integer - optional timeout in ms, default Infinity. Aborts with error.
    @param opts.verbose boolean - optional flag to turn on debug log
    @param opts.window integer - optional stabilization time in ms, default 750ms. Waits this amount of time for file sizes to stabilize or other resource availability to remain unchanged. If less than interval then will be reset to interval
-   @param cb optional callback function with signature cb(err) - if err is provided then, resource checks did not succeed
+   @param [cb] optional callback function with signature cb(err) - if err is provided then, resource checks did not succeed
    if not specified, wait-on will return a promise that will be rejected if resource checks did not succeed or resolved otherwise
  */
 function waitOn(opts, cb) {


### PR DESCRIPTION
I noticed my IDE was complaining that the second parameter to `waitOn` was missing:

<img width="617" alt="image" src="https://github.com/user-attachments/assets/897491e7-1fcd-46ba-a16b-171b2236b136" />

It seems the function is just missing the square brackets in the JSDoc to indicate it is optional. See https://jsdoc.app/tags-param#optional-parameters-and-default-values