### PR TITLE
fix: update axios to 1.12.0 to fix CVE-2025-58754

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "8.0.4",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "joi": "^17.13.3",
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
@@ -545,9 +545,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.1.tgz",
+      "integrity": "sha512-Kn4kbSXpkFHCGE6rBFNwIv0GQs4AvDT80jlveJDKFxjbTYMUeB4QtsdPCv6H8Cm19Je7IU6VFtRl2zWZI0rudQ==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "temp": "^0.9.4"
   },
   "dependencies": {
-    "axios": "^1.11.0",
+    "axios": "^1.12.0",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
     "minimist": "^1.2.8",


### PR DESCRIPTION
### Description
Axios was recently updated to fix CVE-2025-58754. This PR is to update to axios 1.12.0

This fixes a vulnerability regarding DoS

#### More information:
https://nvd.nist.gov/vuln/detail/CVE-2025-58754
[GHSA-4hjh-wcwx-xvwj](https://github.com/axios/axios/security/advisories/GHSA-4hjh-wcwx-xvwj)