### PR TITLE
feat: add TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,66 @@
+/// <reference types="node" />
+
+import { SecureContextOptions } from 'tls';
+
+declare function waitOn(opts: waitOn.WaitOnOptions, cb: (err: Error | null) => void): void;
+declare function waitOn(opts: waitOn.WaitOnOptions): Promise<void>;
+
+declare namespace waitOn {
+  interface WaitOnOptions extends Pick<SecureContextOptions, 'ca' | 'cert' | 'key' | 'passphrase'> {
+    /** Array of resources to wait for. Prefix determines type: file:, http:, https:, http-get:, https-get:, tcp:, socket: */
+    resources: string[];
+    /** Initial delay in ms before polling begins. @default 0 */
+    delay?: number;
+    /** HTTP HEAD/GET timeout in ms. */
+    httpTimeout?: number;
+    /** Poll interval in ms. @default 250 */
+    interval?: number;
+    /** Log remaining resources to stdout. @default false */
+    log?: boolean;
+    /** Reverse mode: succeed when resources are NOT available. @default false */
+    reverse?: boolean;
+    /** Max concurrent connections per resource. @default Infinity */
+    simultaneous?: number;
+    /** Overall timeout in ms. Rejects/errors when exceeded. @default Infinity */
+    timeout?: number;
+    /** Custom function to determine if an HTTP status code is a success. Defaults to 2xx. */
+    validateStatus?: ValidateStatus;
+    /** Enable debug output (also enables log). @default false */
+    verbose?: boolean;
+    /** Stabilization window in ms. Resource must remain available for this duration. @default 750 */
+    window?: number;
+    /** TCP connect timeout in ms. @default 300 */
+    tcpTimeout?: number;
+
+    /** HTTP proxy configuration. Set to false to disable. @default undefined */
+    proxy?: false | WaitOnProxyOptions;
+    /** HTTP Basic auth credentials. */
+    auth?: WaitOnAuth;
+    /** Reject unauthorized TLS certificates. @default false */
+    strictSSL?: boolean;
+    /** Follow HTTP 3xx redirects. @default true */
+    followRedirect?: boolean;
+    /** Additional HTTP request headers. */
+    headers?: Record<string, string>;
+  }
+
+  interface WaitOnAuth {
+    username: string;
+    password: string;
+  }
+
+  interface WaitOnProxyOptions {
+    host: string;
+    port: number;
+    /** @default 'http' */
+    protocol?: string;
+    auth?: {
+      username: string;
+      password: string;
+    };
+  }
+
+  type ValidateStatus = (status: number) => boolean;
+}
+
+export = waitOn;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,14 @@
         "wait-on": "bin/wait-on"
       },
       "devDependencies": {
+        "@types/node": "^25.5.0",
         "chai": "^6.2.2",
         "eslint": "^9.39.1",
         "eslint-plugin-chai-friendly": "^1.1.0",
         "mkdirp": "^3.0.1",
         "mocha": "^11.7.5",
-        "temp": "^0.9.4"
+        "temp": "^0.9.4",
+        "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -423,6 +425,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -2244,6 +2256,27 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "9.0.4",
   "type": "commonjs",
   "main": "lib/wait-on",
+  "types": "index.d.ts",
   "bin": {
     "wait-on": "bin/wait-on"
   },
@@ -26,12 +27,14 @@
     "node": ">=20.0.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "chai": "^6.2.2",
     "eslint": "^9.39.1",
     "eslint-plugin-chai-friendly": "^1.1.0",
     "mkdirp": "^3.0.1",
     "mocha": "^11.7.5",
-    "temp": "^0.9.4"
+    "temp": "^0.9.4",
+    "typescript": "^6.0.2"
   },
   "dependencies": {
     "axios": "^1.13.5",


### PR DESCRIPTION
Add typescript definitions for wait-on package. The base was taken from the [DefinitelyTyped repository](https://raw.githubusercontent.com/DefinitelyTyped/DefinitelyTyped/refs/heads/master/types/wait-on/index.d.ts), but was modified to be more accurate and to include only the relevant types from SecureContextOptions (since those are validated by the Joi schema in the codebase).

I've taken the path of defining them in a separate file, so we don't have to add a transpilation step to the build process, and making the types available to users of the package without needing to install @types/wait-on separately.

Resolves: https://github.com/jeffbski/wait-on/issues/35