### PR TITLE
add .fastembed_cache and .github to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 /src/
 test/
+.fastembed_cache
+.github


### PR DESCRIPTION
Removes both from being published to npm package.

Resolves: #207 Thanks @aarongoldenthal
