### PR TITLE
fix: use HTTPS repository URL instead of HTTP

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Jeff Barczewski <info@codewinds.com>",
   "repository": {
     "type": "git",
-    "url": "http://github.com/jeffbski/wait-on.git"
+    "url": "https://github.com/jeffbski/wait-on.git"
   },
   "bugs": {
     "url": "http://github.com/jeffbski/wait-on/issues"


### PR DESCRIPTION
## Summary

The `repository.url` field in `package.json` uses `http://github.com/jeffbski/wait-on.git` (insecure HTTP).

For a public npm package, HTTPS (`https://github.com/jeffbski/wait-on.git`) is universally accessible and secure.

## Change
- `http://github.com/jeffbski/wait-on.git` → `https://github.com/jeffbski/wait-on.git`

No runtime code, dependency, or test changes.